### PR TITLE
Added an 'extra_hosts' section to the cli container.

### DIFF
--- a/assets/docker-compose.yml
+++ b/assets/docker-compose.yml
@@ -38,6 +38,8 @@ services:
       - container:amazeeio-ssh-agent
     environment:
       << : *default-environment # loads the defined environment variables from the top
+    extra_hosts:
+    - "${COMPOSE_PROJECT_NAME}.docker.amazee.io:172.17.0.1"
 
   nginx:
     build:


### PR DESCRIPTION
Thanks to that it's possible to run phpunit via a remote interpreter (SIMPLETEST_BASE_URL=${COMPOSE_PROJECT_NAME}.docker.amazee.io)