### PR TITLE
Comment out SB_JIRA_PASS

### DIFF
--- a/src/AmazeeLabs/Silverback/Commands/Init.php
+++ b/src/AmazeeLabs/Silverback/Commands/Init.php
@@ -56,7 +56,8 @@ class Init extends SilverbackCommand {
       ],
       'SB_JIRA_PASS' => [
         'value' => '',
-        'description' => 'Jira password.',
+        'description' => 'Jira password. This variable is commented out by default to not override the Travis value (passwords are usually added as a secured environment variables in Travis). Uncomment it in your .env file.',
+        'commentOut' => TRUE,
       ],
       'SB_JIRA_PROJECTS' => [
         'value' => '',
@@ -115,7 +116,8 @@ class Init extends SilverbackCommand {
     }
 
     file_put_contents($this->rootDirectory . '/.env.example', implode("\n", array_map(function ($env) use ($environment) {
-      return "# {$environment[$env]['description']}\n$env=\"{$environment[$env]['value']}\"\n";
+      $commentSign = empty($environment[$env]['commentOut']) ? '' : '# ';
+      return "# {$environment[$env]['description']}\n{$commentSign}{$env}=\"{$environment[$env]['value']}\"\n";
     }, array_keys($environment))));
 
     $composerJson = json_decode(file_get_contents($this->rootDirectory . '/composer.json'), TRUE);


### PR DESCRIPTION
This is something we encountered when were setting up Cypress testing on a new project:
- `SB_JIRA_PASS` is set to empty string by default
- in .travis.yml we run `source .envrc`
- this copies `.env.example` to `.env` and loads all vars from it
- result: Travis' SB_JIRA_PASS env var value is overridden with an empty string

The easiest way to solve this was to comment out `SB_JIRA_PASS` in `.env.example`.