### PR TITLE
Do not use cypress tags by default

### DIFF
--- a/src/AmazeeLabs/Silverback/Commands/Init.php
+++ b/src/AmazeeLabs/Silverback/Commands/Init.php
@@ -71,8 +71,8 @@ class Init extends SilverbackCommand {
         'description' => 'Cypress base url.'
       ],
       'CYPRESS_TAGS' => [
-        'value' => '@assignee:$SB_JIRA_USER and @WIP',
-        'description' => '`cypress run` will only execute tests based on tags.'
+        'value' => '',
+        'description' => '`cypress run` will only execute tests based on tags. Examples: "@assignee:$SB_JIRA_USER and @WIP", "@COMPLETED".'
       ],
     ];
 


### PR DESCRIPTION
When running tests in Travis, we override `CYPRESS_TAGS`: https://github.com/AmazeeLabs/silverback/blob/76c0d7daeb0d1f4b7094318d694fff7dd3babda5/assets/.travis.yml#L32

When running tests locally, we usually run `cypress open` and then select a test, or hit "Run all specs". When you do this for the first time, and `CYPRESS_TAGS` is `@assignee:$SB_JIRA_USER and @WIP`, you see the following:
- Cypress UI shows available tests
- clicking on a test or hitting "Run all specs" results in
```
No tests found in your file:
/path/to/project/tests/cypress/__all
We could not detect any tests in the above file. Write some tests and re-run.
```
This is so much confusing. There are tests, but it says there is none.

I'd make `CYPRESS_TAGS` empty by default.

(But. We are just start working with Cypress. And my "we usually run" is just a guess.) 