### PR TITLE
Add to README: a way to check direnv setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,19 @@ composer require amazeelabs/silverback
 yarn
 ```
 
-If you've set up `direnv` correctly, it will complain at this point that there is an unknown `.envrc` file. Just execute `direnv allow` to enable it. From now own environment variables and executable search paths will be set automatically whenever you enter this directory.
+If you've set up `direnv` correctly, it will complain at this point that there is an unknown `.envrc` file. Just execute `direnv allow` to enable it. From now own environment variables and executable search paths will be set automatically whenever you enter this directory. Here is how it should look in case of a correct installation:  
+```
+me@local:~/Project $ cd my-project/
+direnv: error .envrc is blocked. Run `direnv allow` to approve its content.
+me@local:~/Project/my-project $ direnv allow
+direnv: loading .envrc
+direnv: export +CYPRESS_BASE_URL ... +SB_TEST_CONTENT ~PATH
+me@local:~/Project/my-project $ cd ..
+direnv: unloading
+me@local:~/Project $ cd my-project/
+direnv: loading .envrc
+direnv: export +CYPRESS_BASE_URL ... +SB_TEST_CONTENT ~PATH
+```
 
 Requiring and initating the package did a couple of things:
 

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ yarn
 
 If you've set up `direnv` correctly, it will complain at this point that there is an unknown `.envrc` file. Just execute `direnv allow` to enable it. From now own environment variables and executable search paths will be set automatically whenever you enter this directory. Here is how it should look in case of a correct installation:  
 ```
-me@local:~/Project $ cd my-project/
+me@local:~/Projects $ cd my-project/
 direnv: error .envrc is blocked. Run `direnv allow` to approve its content.
-me@local:~/Project/my-project $ direnv allow
+me@local:~/Projects/my-project $ direnv allow
 direnv: loading .envrc
 direnv: export +CYPRESS_BASE_URL ... +SB_TEST_CONTENT ~PATH
-me@local:~/Project/my-project $ cd ..
+me@local:~/Projects/my-project $ cd ..
 direnv: unloading
-me@local:~/Project $ cd my-project/
+me@local:~/Projects $ cd my-project/
 direnv: loading .envrc
 direnv: export +CYPRESS_BASE_URL ... +SB_TEST_CONTENT ~PATH
 ```


### PR DESCRIPTION
We have found that it may be hard for developers not experienced with bash/shell to setup direnv.

The worst case was:
- ``direnv: error .envrc is blocked. Run `direnv allow` to approve its content.`` was appearing when switching to the project dir
- running `direnv allow` removed the warning
- nothing else happened - env vars were not loaded

Developers should have a way to verify whether direnv is setup correctly. I found no better way other than what you can see in this PR.