### PR TITLE
Prevent an infinite wait for drush serve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,14 @@ install:
 script:
 - silverback setup
 - drush serve :8889 > log.txt 2>&1 &
-- until netstat -an 2>/dev/null | grep '8889.*LISTEN'; sleep 1; curl -I http://127.0.0.1:8889 ; do true; done
+  # Wait for drush serve to start up, but only for 20 seconds.
+  - DRUSH_SERVE_WAIT=0
+  - until netstat -an 2>/dev/null | grep '8889.*LISTEN'; \
+      sleep 1; curl -I http://127.0.0.1:8889 \
+      || DRUSH_SERVE_WAIT=$(($DRUSH_SERVE_WAIT + 1)) \
+      && echo "Waited $DRUSH_SERVE_WAIT seconds for drush serve." \
+      && (($DRUSH_SERVE_WAIT > 19)) ; \
+      do true; done
 - composer run-script run-tests --timeout 0
 - cd $TRAVIS_BUILD_DIR/docs && npm run build
 - kill $(jobs -p) || true

--- a/assets/.travis.yml
+++ b/assets/.travis.yml
@@ -14,7 +14,8 @@ cache:
   - ~/.composer/cache
 
 before_install:
-  - echo 'sendmail_path = /bin/true' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo 'sendmail_path = /bin/true' \
+      >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - phpenv config-rm xdebug.ini
   - composer self-update
 
@@ -27,7 +28,14 @@ script:
   - silverback setup
   - if [[ -n "$SB_JIRA_PROJECTS" ]]; then silverback download-tests; fi
   - drush serve 8889 > log.txt 2>&1 &
-  - until netstat -an 2>/dev/null | grep '8889.*LISTEN'; sleep 1; curl -I http://127.0.0.1:8889 ; do true; done
+  # Wait for drush serve to start up, but only for 20 seconds.
+  - DRUSH_SERVE_WAIT=0
+  - until netstat -an 2>/dev/null | grep '8889.*LISTEN'; \
+      sleep 1; curl -I http://127.0.0.1:8889 \
+      || DRUSH_SERVE_WAIT=$(($DRUSH_SERVE_WAIT + 1)) \
+      && echo "Waited $DRUSH_SERVE_WAIT seconds for drush serve." \
+      && (($DRUSH_SERVE_WAIT > 19)) ; \
+      do true; done
   - if [[ -d web/modules/custom ]]; then phpunit web/modules/custom; fi
   - |
     cd tests


### PR DESCRIPTION
The Travis script is written so that it will wait FOREVER for drush serve to load.

If drush serve has an error and does not start up, the Travis test will run forever until it is manually cancelled or until Travis thinks we've used all our allocated services for the month.

This change assumes that if drush serve doesn't start in 20 seconds, it's not going to start at all and exits with an error.