### PR TITLE
Improve Drupal installation 

### DIFF
--- a/assets/.lagoon.yml
+++ b/assets/.lagoon.yml
@@ -19,7 +19,7 @@ tasks:
         command: |
             if ! drush status --fields=bootstrap | grep -q "Successful"; then
                 # no drupal installed, we install drupal from scratch
-                drush si -y minimal --sites-subdir=default --config-dir=../config/sync --account-name=admin --account-pass=admin
+                drush si -y minimal --sites-subdir=default --existing-config --account-name=admin --account-pass=admin
             fi
         service: cli
         shell: bash

--- a/src/AmazeeLabs/Silverback/Commands/Setup.php
+++ b/src/AmazeeLabs/Silverback/Commands/Setup.php
@@ -67,7 +67,7 @@ class Setup extends SilverbackCommand {
         $this->executeProcess([
           './vendor/bin/drush', 'si', '-y', 'minimal',
           '--sites-subdir', $siteDir,
-          '--config-dir', '../' . $configDir,
+          '--existing-config',
           '--account-name', getenv('SB_ADMIN_USER'),
           '--account-pass', getenv('SB_ADMIN_PASS'),
         ], $output);

--- a/src/AmazeeLabs/Silverback/Commands/Setup.php
+++ b/src/AmazeeLabs/Silverback/Commands/Setup.php
@@ -71,6 +71,7 @@ class Setup extends SilverbackCommand {
           '--account-name', getenv('SB_ADMIN_USER'),
           '--account-pass', getenv('SB_ADMIN_PASS'),
         ], $output);
+        $this->executeProcess(['./vendor/bin/drush', 'cim', '-y'], $output);
 
         $zippy->create('install-cache.zip', [
           'files' => 'web/sites/' . $siteDir . '/files',


### PR DESCRIPTION
Small improvements for `silverback setup`:
- replace deprecated `--config-dir` with `--existing-config`
- import config after installation