### PR TITLE
Removed patch '#3065212 Workspaces views multiply rows by language' a…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,8 +57,7 @@
                 "#3045177 workspace specific latest revision": "https://www.drupal.org/files/issues/2019-04-08/3045177-10.patch",
                 "#3037136 allow workspaces and content moderation to be installed together": "https://www.drupal.org/files/issues/2019-06-27/3037136-6.patch",
                 "#2803717 allow changes in content moderation without new revision": "https://www.drupal.org/files/issues/2019-04-17/2803717-48.patch",
-                "#3068733 EntityStorageBase::loadMultiple returns unwanted entities when the static cache is warm.": "https://www.drupal.org/files/issues/2019-08-05/3068733-11.patch",
-                "#3065212 Workspaces views multiply rows by language": "https://www.drupal.org/files/issues/2019-07-11/3065212-14.patch"
+                "#3068733 EntityStorageBase::loadMultiple returns unwanted entities when the static cache is warm.": "https://www.drupal.org/files/issues/2019-08-05/3068733-11.patch"
             }
         }
     },


### PR DESCRIPTION
…s it got committed to 8.7.6