### PR TITLE
Clear caches in case of a setup with an existing install-cache

### DIFF
--- a/src/AmazeeLabs/Silverback/Commands/Setup.php
+++ b/src/AmazeeLabs/Silverback/Commands/Setup.php
@@ -59,8 +59,9 @@ class Setup extends SilverbackCommand {
         if ($input->getOption('cypress')) {
           $baseCommand[] = '--uri=http://localhost:8889';
         }
-        $this->executeProcess(array_merge($baseCommand, ['updb', '-y']), $output);
+        $this->executeProcess(array_merge($baseCommand, ['updb', '-y', '--cache-clear=0']), $output);
         $this->executeProcess(array_merge($baseCommand, ['cim', '-y']), $output);
+        $this->executeProcess(array_merge($baseCommand, ['cr']), $output);
       }
       else {
         $this->executeProcess([


### PR DESCRIPTION
Install-cache already contains caches (e.g. for routes) and those needs to be rebuilt with the fresh codebase.

(and `drush updb -y` does not clear caches automatically in case if there are no updates)