### PR TITLE
WIP: Improve storybook config

### DIFF
--- a/assets/storybook/.storybook/config.js
+++ b/assets/storybook/.storybook/config.js
@@ -15,11 +15,9 @@ import '../styles.css';
 addDrupalFilters(Twig);
 
 // Automatically import all files ending in *.stories.js
-const twig = require.context('../twig', true, /\.stories\.(ts|js)$/);
-const editor = require.context('../editor', true, /\.stories\.(ts|js)$/);
+const stories = require.context('../', true, /\.stories\.(ts|js)$/);
 function loadStories() {
-  twig.keys().forEach(filename => twig(filename));
-  editor.keys().forEach(filename => editor(filename));
+  stories.keys().forEach(filename => stories(filename));
 }
 
 // Helps make UI components more accessible.

--- a/assets/storybook/.storybook/config.js
+++ b/assets/storybook/.storybook/config.js
@@ -6,13 +6,13 @@ import { addDecorator, configure } from '@storybook/html';
 import { withA11y } from '@storybook/addon-a11y';
 
 import Twig from 'twig';
-import twigDrupal from 'twig-drupal-filters';
+import addDrupalFilters from 'twig-drupal-filters';
 
 // Import styles
 import '../styles.css';
 
 // Add the filters to Drupal.
-twigDrupal(Twig);
+addDrupalFilters(Twig);
 
 // Automatically import all files ending in *.stories.js
 const twig = require.context('../twig', true, /\.stories\.(ts|js)$/);


### PR DESCRIPTION
We need to streamline and fix bugs in the storybook config.

This is a WIP.

TODO:
- TypeScript:
  - Fix TypeScript error: `Do not use "// @ts-ignore" comments because they suppress compilation errors`
  - Eslinting of Typescript may be buggy. `WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-estree. SUPPORTED TYPESCRIPT VERSIONS: >=3.2.1 <3.6.0`
- Remove arbitrary separation of "editor" from "twig" components
- Add "templates" to separate GraphQL from reusable components
- Prevent assets (fonts, images) from being inlined by default
- CSS imports from config.js don't work as expected