### PR TITLE
Allow Xdebug to work with Twig templates

### DIFF
--- a/assets/web/sites/default/amazeeio.development.services.yml
+++ b/assets/web/sites/default/amazeeio.development.services.yml
@@ -8,7 +8,7 @@ parameters:
   twig.config:
     debug: true # displays twig debug messages, developers like them :)
     auto_reload: true # reloads the twig files on every request, so no drush cache clear is required
-    cache: false # No twig internal cache, important: check the example.settings.loca.php to fully fully disable the twig cache
+    cache: true # Twig cache allows Xdebug to work with .twig files
 
 services:
   cache.backend.null: # Defines a Cache Backend Factory which is just empty, it is not used by default


### PR DESCRIPTION
This change is copy over a proposed change to Amazee.io's boilerplate yml files.

https://github.com/amazeeio/lagoon/issues/1238