### PR TITLE
Add entity_usage to enabled modules.

### DIFF
--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -18,6 +18,7 @@ module:
   delivery: 0
   dynamic_page_cache: 0
   editor: 0
+  entity_usage: 0
   field: 0
   field_ui: 0
   file: 0


### PR DESCRIPTION
This commit https://github.com/AmazeeLabs/delivery/commit/5948a2095720e58f177a4f183e48621d971189cb in `amazeelabs/delivery` introduced a dependency on `entity_usage`. Without this addition a new installation of silverback fails like this:

$ silverback setup

`Unable to install the `Delivery` module since it requires the `Entity Usage` module.` 

[warning] Drush command terminated abnormally. Check for an exit() in your Drupal site.

In SilverbackCommand.php line 37:                                                                                                                                                                   
  The command "'./vendor/bin/drush' 'si' '-y' 'minimal' '--sites-subdir' 'default' '--existing-config' '--account-name' 'admin' '--account-pass' 'admin'" failed.                                                                                                                                                                     
  Exit Code: 1(General error)