### PR TITLE
Allow Varnish caching by default

### DIFF
--- a/assets/docker-compose.yml
+++ b/assets/docker-compose.yml
@@ -127,7 +127,7 @@ services:
       - nginx # links varnish to the nginx in this docker-compose project, or it would try to connect to any nginx running in docker
     environment:
       << : *default-environment
-      VARNISH_BYPASS: "true" # by default we bypass varnish, change to 'false' or remove in order to tell varnish to cache if possible
+      VARNISH_BYPASS: "false" # Change to "true" to disable Varnish caching.
     networks:
       - amazeeio-network
       - default


### PR DESCRIPTION
There is no reason to bypass Varnish on a Lagoon setup. Because there are two routes prefixed with `varnish-` and `nginx-` that could be used.