### PR TITLE
Updated .envrc to use PATH_add instead of a single line export

### DIFF
--- a/assets/.envrc
+++ b/assets/.envrc
@@ -3,7 +3,9 @@
 # https://direnv.net/
 
 # Add the current composer bin directory to $PATH
-export PATH=$(pwd)/vendor/bin:$(pwd)/node_modules/.bin:$(pwd)/tests/node_modules/.bin:$PATH
+PATH_add $(pwd)/vendor/bin
+PATH_add $(pwd)/node_modules/.bin
+PATH_add $(pwd)/tests/node_modules/.bin
 
 # Copy .env.example to .env if necessary
 if [ ! -f .env ]; then


### PR DESCRIPTION
A very small & optional change. 

Instead of having all exported paths on a single line, we can use PATH_add, as described on the documentation:
https://direnv.net/#the-stdlib 